### PR TITLE
Test for nans in cost matrix

### DIFF
--- a/src/Munkres.jl
+++ b/src/Munkres.jl
@@ -60,6 +60,7 @@ function munkres(cost_matrix)
     # and by and Yi Cao's surprisingly fast matlab version,
     # http://mathworks.com/matlabcentral/fileexchange/20328-munkres-assignment-algorithm
 
+    any(isnan, cost_matrix) && error("cost matrix cannot have NaNs")
     n,m = size(cost_matrix)
     flipped = false
     if n > m

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,3 +103,7 @@ tst = [351.0 300.0 662.0 337.0 384.0 935.0 650.0 446.0 57.0 295.0 168.0 398.0 81
 p = [9, 6, 18, 3, 4, 17, 16, 7, 13, 20]
 
 @test munkres(tst) == p
+
+@test_throws ErrorException munkres(fill(NaN, (3,3)))
+
+nothing


### PR DESCRIPTION
If the cost matrix has nans, `munkres` goes into an endless loop. Better to throw immediately.